### PR TITLE
Fix: Credentials are now used when test connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+target/
+mqtt-notification-plugin.iml

--- a/src/main/resources/jenkins/plugins/mqttnotification/MqttNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/mqttnotification/MqttNotifier/config.jelly
@@ -3,11 +3,11 @@
         <f:textbox />
     </f:entry>
 
-    <f:validateButton method="testConnection" title="Test connection" with="brokerUrl" progress="Testing..." />
-
     <f:entry title="Credentials" field="credentialsId">
         <f:select/>
     </f:entry>
+
+    <f:validateButton method="testConnection" title="Test connection" with="brokerUrl,credentialsId" progress="Testing..." />
 
     <f:entry title="Topic" field="topic">
         <f:textbox />


### PR DESCRIPTION
Credentials have been ignored, when the „test connection“ button was used.

See https://issues.jenkins-ci.org/browse/JENKINS-29020