### PR TITLE
Add call to mqtt.close() to release the resources (prevent remaining …

### DIFF
--- a/src/main/java/jenkins/plugins/mqttnotification/MqttNotifier.java
+++ b/src/main/java/jenkins/plugins/mqttnotification/MqttNotifier.java
@@ -217,6 +217,7 @@ public class MqttNotifier extends Notifier implements SimpleBuildStep {
                 this.isRetainMessage()
             );
             mqtt.disconnect();
+			mqtt.close(); // Release the resources
         } catch (final MqttException me) {
             logger.println("ERROR: Caught MqttException while configuring MQTT connection: " + me.getMessage());
             me.printStackTrace(logger);

--- a/src/main/java/jenkins/plugins/mqttnotification/MqttNotifier.java
+++ b/src/main/java/jenkins/plugins/mqttnotification/MqttNotifier.java
@@ -217,7 +217,7 @@ public class MqttNotifier extends Notifier implements SimpleBuildStep {
                 this.isRetainMessage()
             );
             mqtt.disconnect();
-			mqtt.close(); // Release the resources
+            mqtt.close(); // Release the resources
         } catch (final MqttException me) {
             logger.println("ERROR: Caught MqttException while configuring MQTT connection: " + me.getMessage());
             me.printStackTrace(logger);
@@ -268,6 +268,7 @@ public class MqttNotifier extends Notifier implements SimpleBuildStep {
 
                 mqtt.connect(mqttConnectOptions);
                 mqtt.disconnect();
+                mqtt.close() // Release the resource
                 return FormValidation.ok("Success");
             } catch (final MqttException me) {
                 return FormValidation.error(me, "Failed to connect");


### PR DESCRIPTION
Hi,
We got into an issue that the jenkins threads count  increased without stopping.
We noticed that the MQTT notification plugin creates a thread without closing it.
so after some investigation we found this open bug https://issues.jenkins-ci.org/browse/JENKINS-52767 and the fix for this issue was to add a call to the close() function that release the resources.